### PR TITLE
Add bi-directional approach for Advisors

### DIFF
--- a/wg-advisors/README.md
+++ b/wg-advisors/README.md
@@ -89,6 +89,19 @@ You are a colleague - a peer. You are not in a position of authority.
 You cannot tell the PMC what to do. You are only an observer, and, at
 the indulgence of the PMC, advisor. Do not abuse this relationship.
 
+## Bi-directional
+
+Advisors are not just there to provide advice based on the best practices
+and rules of the Foundation. They are also there to learn from the
+project, and to bring back to ComDev and the Board the ways how many of
+the projects apply the rules and best practices in their practices and
+culture, taking into accounts individual project's needs and
+circumstances. This might lead to updating and adjusting the common
+understanding of the best practices and rules and how they apply in
+various circumstances, bringing the useful feedback to the Board and
+ComDev.
+
+
 ## FAQ
 
 ### Why a member?


### PR DESCRIPTION
This is something I wanted to proposed from the beginnig of seing the Sharpenes apporach. I believe the original approach where Advisors just advise the projects their join - and the flow is in one direction, they should treat the opportunity of interacting with different PMCs as an opportunity to learn from the projects and discuss with other advisors whether the current incarnation of the rules we have is applicable in practice and whether maybe they should be adjusted and improved or maybe they should be updated to be better applicable to different projects - coming from various culturs, backgrounds, projects with different sizes, with different stakeholder engagement.

Having the relation works in both directions is an opportunity to learn and adapt, and to exchange findings between the Advisors that might lead to better adaptability and better common understanding of the rules and policies we have, and more participatory role of both Advisors and PMCs that might get beter chance to shape the way how Foundation works on an ongoing way, as well as to give the board an opportunity to listen to the voices and better understand the varuious needs of various projects.