### PR TITLE
Add a chapter about "collaborative" aspect of Advisors

### DIFF
--- a/wg-advisors/README.md
+++ b/wg-advisors/README.md
@@ -101,6 +101,16 @@ understanding of the best practices and rules and how they apply in
 various circumstances, bringing the useful feedback to the Board and
 ComDev.
 
+## Collaborative
+
+Advisors are encouraged to share their experiences and exchange best
+practices and ideas with each other, and to collaborate on the best ways to
+help the projects and to transfer best practices and experiences of
+the various PMCs between each other. They comdev mailing list and this
+repository where "whys" and a little "hows" of the best practices and
+rules are discussed and documented serve as as platform of this
+collaboration.
+
 
 ## FAQ
 


### PR DESCRIPTION
Having a - potentially - bigger and engaged group of Advisors that can exchange best practices they learn from the project and have the possibility of shaping best practices that other Advisors will also disseminate among other projects, is probably one of the biggest values of a group such as Advisors and we should state it explicitly that such collaboration is expected and encouraged.

Also this might be one of the important incentives for Advisors to get engaged, and for PMCs to ask for Advisors when they know that whatever they do with Advisors is not only to apply "top-bottom" rules and principles, but also to be able to share their own practices and ideas and variations coming from different stages, size, stakeholder engagement they are in - and knowing that they can also shape the common understanding and interpretation of the rules and principles the ASF is built on.

Fingers crossed that we will be able to incentivise enough engaged members and PMCs to make Advisors a useful platformm for this kind of collaboration.