### PR TITLE
chore: send notification to a separate list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -8,6 +8,6 @@ github:
 
 notifications:
   commits:      commits@community.apache.org
-  issues:       notification@community.apache.org
-  pullrequests: notification@community.apache.org
+  issues:       notifications@community.apache.org
+  pullrequests: notifications@community.apache.org
   jira_options: link label

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -8,6 +8,6 @@ github:
 
 notifications:
   commits:      commits@community.apache.org
-  issues:       dev@community.apache.org
-  pullrequests: dev@community.apache.org
+  issues:       notification@community.apache.org
+  pullrequests: notification@community.apache.org
   jira_options: link label


### PR DESCRIPTION
A peer to https://github.com/apache/comdev-site/pull/64.

I'm thinking of it as the first place (to commits@), but I'm unsure how many people are subscribing to notifications from GitHub, so I postponed the action.

But now we have a similar patch at comdev-site so I'd suggest we apply to this repo also.