### PR TITLE
Restructure the red flags and add placeholders for more whys

### DIFF
--- a/wg-advisors/red-flags.md
+++ b/wg-advisors/red-flags.md
@@ -8,35 +8,64 @@ and sharpen, our projects.
 Remember, always, that you are a colleague, coming alongside a project,
 not a policeman enforcing the rules.
 
-## Common red flags
+We divided the common red flags into categories and provided additional
+explanation on why we should look for these red flags in the
+[why](why) section of the WG.
 
-* Is unsure when to recognise committers
-* Is having online meetings that are not brought back to the mailing list.
-* Has a website external to apache.org
-* Is missing reports
-* Is missing release votes: [why release process](why/why_release_process.md)
-* Has too many release candidates: [why engage community](why/why_release_process.md)
-* Has author tags in the code
-* Discussions are happening off-list.
-* Too much talk is happening on the private list.
-* Users' questions are going unanswered on the mailing list.
-* Users' reported issues are going uncommented and untouched.
-* Users' PRs are going unreviewed and/or unmerged.
+## Release process
+
+Explanation on [why we have strict release process](why/why_release_process.md) 
+
+* Is missing release votes
+* Has too many release candidates
+* The PMC is making releases without voting on them
+* Releases are not being placed in the ASF distribution system
 * No new release for a long time, especially when new contributions was merged.
-* There is little or no activity on the mailing list.
-* There are many GitHub or version control notifications on the mailing list.
-* Building the project is challenging.
-* Getting the LICENSE and NOTICE correct is difficult.
-* The PMC is making releases without voting on them: [why release process](why/why_release_process.md)
-* The PMC members are not looking after the project's name and brand.
+
+## Building your diverse and vendor-neutral community
+
+Explanation on [why we should build our community](why/why_build_community.md)
+
+* The project has a benevolent dictator.
+* Has author tags in the code
+* Is unsure when to recognise committers
 * No PMC members have been elected for a while
 * No committers have been elected for a while.
 * The project is having trouble attracting contributors.
-* PMC members are not signed up to the private mailing list.
-* The project has a benevolent dictator.
-* A single company is controlling the direction of the project.
-* Releases are not being placed in the ASF distribution system: [why release process](why/why_release_process.md)
-* The project is voting on too many things.
-* PMC members have a conflict of interest.
-* Conversations on the mailing list mainly occur in a language other than English.
 * Only a few core people are contributing code, especially if they are from one company.
+* Users' reported issues are going uncommented and untouched.
+* Users' questions are going unanswered on the mailing list.
+* Users' PRs are going unreviewed and/or unmerged.
+* Building the project is challenging.
+* A single company is controlling the direction of the project.
+* PMC members have a conflict of interest.
+
+## Discussions and decision-making
+
+Explanation on [why discussions and decision-making should be on list](why/why_discussions_and_decisions.md)
+
+* Is having online meetings that are not brought back to the mailing list.
+* Discussions are happening off-list.
+* There is little or no activity on the mailing list.
+* Conversations on the mailing list mainly occur in a language other than English.
+* Too much talk is happening on the private list.
+* There are many GitHub or version control notifications on the mailing list.
+* PMC members are not signed up to the private mailing list.
+* The project is voting on too many things.
+
+## Branding, identity and licencing
+
+Explanation on [why we should look after the project's brand and licencing](why/why_branding_licencing.md)
+
+* Has a website external to apache.org
+* Getting the LICENSE and NOTICE correct is difficult.
+* The PMC members are not looking after the project's name and brand.
+
+## Reports to the board
+
+Explanation on [why we should send reports to the ASF Board](why/why_reports_to_board.md)
+
+* Is missing reports
+* Reports are prepared by just copy-pasting the template or previous report
+* Reports are not reflecting true state of the project
+* There are no discussions on the report in the mailing lists

--- a/wg-advisors/why/why_branding_licencing.md
+++ b/wg-advisors/why/why_branding_licencing.md
@@ -1,0 +1,13 @@
+# Why we should look after the project's brand and licencing
+
+TODO:
+
+## Summary
+
+## Links to relevant documents
+
+## Why are we doing it?
+
+## Is it mandatory and what are conditions?
+
+## Are there variations for different projects?

--- a/wg-advisors/why/why_build_community.md
+++ b/wg-advisors/why/why_build_community.md
@@ -1,0 +1,13 @@
+# Why we should build our community
+
+TODO:
+
+## Summary
+
+## Links to relevant documents
+
+## Why are we doing it?
+
+## Is it mandatory and what are conditions?
+
+## Are there variations for different projects?

--- a/wg-advisors/why/why_discussions_and_decisions.md
+++ b/wg-advisors/why/why_discussions_and_decisions.md
@@ -1,0 +1,13 @@
+# Why discussion and decision making had to happen on the mailing list
+
+TODO:
+
+## Summary 
+
+## Links to relevant documents
+
+## Why are we doing it?
+
+## Is it mandatory and what are conditions?
+
+## Are there variations for different projects?

--- a/wg-advisors/why/why_reports_to_board.md
+++ b/wg-advisors/why/why_reports_to_board.md
@@ -1,0 +1,13 @@
+# Why we should send reports to the ASF Board
+
+TODO:
+
+## Summary
+
+## Links to relevant documents
+
+## Why are we doing it?
+
+## Is it mandatory and what are conditions?
+
+## Are there variations for different projects?


### PR DESCRIPTION
As proposed before, here is the refactor of the red flags into sections that I believe make sense and added templates to be filled for those section why's.