### PR TITLE
Propose "why" explanation on discussions and decision making

### DIFF
--- a/wg-advisors/red-flags.md
+++ b/wg-advisors/red-flags.md
@@ -45,7 +45,7 @@ Explanation on [why we should build our community](why/why_build_community.md)
 Explanation on [why discussions and decision-making should be on list](why/why_discussions_and_decisions.md)
 
 * Is having online meetings that are not brought back to the mailing list.
-* Discussions are happening off-list.
+* Discussions are happening off-list and are not being brought back to the list.
 * There is little or no activity on the mailing list.
 * Conversations on the mailing list mainly occur in a language other than English.
 * Too much talk is happening on the private list.

--- a/wg-advisors/why/why_discussions_and_decisions.md
+++ b/wg-advisors/why/why_discussions_and_decisions.md
@@ -1,13 +1,92 @@
-# Why discussion and decision making had to happen on the mailing list
-
-TODO:
+# Why discussion and decision-making had to happen on the mailing list
 
 ## Summary 
 
+Discussions and decision-making should happen on the mailing list to ensure that the project is
+transparent and that all decisions are made in the open. This is important to ensure that all
+community members have the opportunity to participate in the decision-making process.
+
 ## Links to relevant documents
+
+* [The Apache Way](https://www.apache.org/theapacheway/)
+* [Mailing list guidelines](https://www.apache.org/foundation/mailinglists.html)
 
 ## Why are we doing it?
 
+In short: because of inclusivity, asynchronous communication need, transparency and the ability to
+preserve the record of the discussions and decisions.
+
+Mailing list the primary communication channel for the project. It has been chosen - at the dawn of the
+Foundation as the primary communication channel because it was the most inclusive and accessible channel
+for all community members, allowing for asynchronous communication and ensuring that all community members
+have the opportunity to participate. All the important decisions and discussions happens there - including
+the decision to invite new committers and PMC members, the decisions to release software, and the decisions
+to change the project's direction.
+
+Why the time passed and technology evolved, the mailing list still keep a lot of the properties that made it
+the primary communication channel for the project. It is still the most inclusive and accessible channel for
+all community members, they allow for asynchronous communication and do not require from the community members
+to be online at the same time and to create accounts with particular external services.
+
+Email is ubiquitous and while not loved by everyone , it has the advantage that you can choose
+the mail clients of your choice, with the features that you like, or even choose a webmail client,
+usually those clients allow you to easily categorise and search the emails, and it's easier to keep track
+of conversations even if you are offline for some time or in a different time zone. The information density
+comparing to online chat is usually higher, so it is a good medium to record decisions and discussions
+about them.
+
+It's very hard to get all those properties in other communication channels and get to agree between all
+the community members to use the same one, while not the best for everyone, it's likely the best as the
+common denominator among the tools and channels you can use.
+
+It is important to stress that we also want to keep a permanent record of the discussions and decisions and
+the Apache Software Foundation Infrastructure team makes sure that the archives are preserved and available
+for the future, including the ability to search and browse the archives, as well as permanently
+link to the discussions and decisions so that they can be always referred to in the future.
+
+The communication on mailing list happens in English, which is the language of the Foundation,
+and the language of the majority of the Foundation's community members. 
+
+An important aspect of using the mailing list is that it allows anyone (including PMC members, committers,
+contributors, and users, but also people from outside - Board members, other PMCs, non-ASF folks) to take
+a look at the way how decisions are made and even participate in the discussions and decisions, and to
+peek into the PMC status. This is important for the Foundation's transparency and for the community building
+process.
+
+PMCs have at least two lists: dev@ and private@ - but it is important to mention that the private@ list should
+only be used for discussions that are absolutely not suitable for public consumption, such as discussions
+about security vulnerabilities, or discussions about individuals that are not suitable for public consumption
+and should be kept private. The private@ list should not be used for discussions about the project's direction,
+voting, releases (except voting and releasing the releases with critical security issue fixes). No project
+decisions should be made on the private@ list in general.
+
 ## Is it mandatory and what are conditions?
 
+Yes, it is mandatory for all ASF projects to have their important discussions and decisions on the mailing
+list, and for many (especially not extremely active) project it might be the only communication method.
+However - and this is described in the following chapter, there are some exceptions and variations.
+
+It is important that the mailing lists of the projects are not flooded with non-important communication, that
+makes is difficult to follow the important discussions and decisions. The PMC members should actively work
+on making sure that the mailing list has a high signal-to-noise ratio, and that the important discussions
+and decisions are not drowned in the noise. This is especially important for projects that have a lot of
+activity and a lot of changes being discussed in parallel.
+
+On the other hand, too little activity on the mailing list might be a red flag, indicating that the project
+is not transparent and that the community members are not participating in the decision-making process.
+
 ## Are there variations for different projects?
+
+With a big number of various communication tools and channels available, and the fact that a lot of them
+are suitable in different contexts (GitHub Issues, PRs, Discussions) and with different speed of interactions,
+some of them being more or less instantaneous, and the PMC might be ok and endorse use of some of the other
+media, but they should be aware that they take on the responsibility to guide and direct people to the mailing
+list when the discussions and decisions are important and should be made in the open and with participation
+of the whole community. This is especially important with projects that have a lot of activity and a lot of
+changes being discussed in parallel - where those changes and discussions have various level of importance
+and impact on the project and the community. Many projects use various communication media, GitHub Issues,
+PRs, Discussions, Slack, JIRA, Discord, etc. for various purposes and in various context.
+
+As long as the PMC members are aware of the importance of the mailing list, and they actively guide and direct
+people to the mailing list when the discussions and decisions - and explain why, and as long as all the
+important decisions and discussions are happening on the mailing list, the PMC is doing the right thing.


### PR DESCRIPTION
This change is a proposal on how we could describe the next "why" that I consider as very important - discussions and decision making.

I tried to map all the red-flags we had for it into a coherent description of the "why" and linked to the two important places in the ASF "rules" that best describe some of the aspects of it.

I think the part of the variations might be contentious, and I hope that in the advisors "leaders" group we can discuss it and get to a consensus that

a) there are good reasons why the mailing lists were chosen in the
   long past

b) the reasons for that are still valid today and mailing list shoud
   remoain the most important place for discussions and decision making

while c) with the current set of technologies in many cases it is not the only way, but as long as PMC actively makes sure that the important discussions and decisions (and generally only those in more active projects) are brought to the list and where list is active and used for all the voting, super important decisions, this is all cool

Looking forward to discussion here.